### PR TITLE
Max age cond clause uses wrong comparison direction

### DIFF
--- a/src/buddy/sign/jws.clj
+++ b/src/buddy/sign/jws.clj
@@ -179,7 +179,7 @@
           (and (:nbf claims) (> now (:nbf claims)))
           (either/left (format "Token is older than :nbf (%s)" (:nbf claims)))
 
-          (and (:iat claims) (number? max-age) (< (- now (:iat claims)) max-age))
+          (and (:iat claims) (number? max-age) (> (- now (:iat claims)) max-age))
           (either/left (format "Token is older than max-age (%s)" max-age))
 
           :else


### PR DESCRIPTION
Switches from lt to gt so that the conditional evaluates to false when the difference between `:iat` and `now` is less than the max-age of the jws token.