### PR TITLE
Added tests for hs256/512 for jws/sign and fixed it

### DIFF
--- a/src/buddy/sign/jws.clj
+++ b/src/buddy/sign/jws.clj
@@ -30,7 +30,7 @@
        :dynamic true}
   *signers-map* {:hs256 {:signer   #(mac/hash %1 {:alg :hmac+sha256 :key %2})
                          :verifier #(mac/verify %1 %2 {:alg :hmac+sha256 :key %3})}
-                 :hs512 {:signer   #(mac/hash %1 %2 {:alg :hmac+sha512 :key %2})
+                 :hs512 {:signer   #(mac/hash %1 {:alg :hmac+sha512 :key %2})
                          :verifier #(mac/verify %1 %2 {:alg :hmac+sha512 :key %3})}
                  :rs256 {:signer   #(dsa/sign %1 {:alg :rsassa-pkcs15+sha256 :key %2})
                          :verifier #(dsa/verify %1 %2 {:alg :rsassa-pkcs15+sha256 :key %3})}

--- a/test/buddy/sign/jws_tests.clj
+++ b/test/buddy/sign/jws_tests.clj
@@ -86,6 +86,18 @@
             (is (= cause :aud)))))))
   )
 
+(deftest jws-hs256-sign-unsign
+  (let [candidate {:foo "bar"}
+        result    (jws/sign candidate secret {:alg :hs256})
+        result'   (jws/unsign result secret {:alg :hs256})]
+    (is (= result' candidate))))
+
+(deftest jws-hs512-sign-unsign
+  (let [candidate {:foo "bar"}
+        result    (jws/sign candidate secret {:alg :hs512})
+        result'   (jws/unsign result secret {:alg :hs512})]
+    (is (= result' candidate))))
+
 (deftest jws-rs256-sign-unsign
   (let [candidate {:foo "bar"}
         result    (jws/sign candidate rsa-privkey {:alg :rs256})


### PR DESCRIPTION
jws/sign is failing with :hs512 algo, there was a typo in the signers-map

    ERROR in (jws-hs512-sign-unsign) (AFn.java:429)
    Uncaught exception, not in assertion.
    expected: nil
      actual: clojure.lang.ArityException: Wrong number of args (3) passed to: mac/hash
     at clojure.lang.AFn.throwArity (AFn.java:429)
        clojure.lang.AFn.invoke (AFn.java:40)
        buddy.sign.jws/fn (jws.clj:33)
        buddy.sign.jws$calculate_signature.invoke (jws.clj:136)

I've written tests for both :hs256 and :hs512 to cover the two missing options.