### PR TITLE
Allow one of multiple issuers when validating claims. Fixes issue #47

### DIFF
--- a/src/buddy/sign/jwt.clj
+++ b/src/buddy/sign/jwt.clj
@@ -23,7 +23,10 @@
                                {now (util/now)}}]
 
   (let [now (util/to-timestamp now)]
-    (when (and iss (not= iss (:iss claims)))
+    (when (and iss (let [iss-claim (:iss claims)]
+                     (if (coll? iss)
+                       (not-any? #{iss-claim} iss)
+                       (not= iss-claim iss))))
       (throw (ex-info (str "Issuer does not match " iss)
                       {:type :validation :cause :iss})))
     (when (and aud (let [aud-claim (:aud claims)]

--- a/test/buddy/sign/jwt_tests.clj
+++ b/test/buddy/sign/jwt_tests.clj
@@ -126,10 +126,18 @@
         (unsign-exp-succ signed candidate {:now 11})))
 
     (testing ":iss claim validation"
-      (let [candidate {:foo "bar" :iss "foo:bar"}
-            signed    (make-jwt-fn candidate)]
-        (unsign-exp-succ signed candidate)
-        (unsign-exp-fail signed :iss {:iss "bar:foo"})))
+      (testing "single issuer special case"
+        (let [candidate {:foo "bar" :iss "foo:bar"}
+              signed    (make-jwt-fn candidate)]
+          (unsign-exp-succ signed candidate)
+          (unsign-exp-fail signed :iss {:iss "bar:foo"})))
+
+      (testing "multi-issuers case"
+        (let [issuers   ["foo:bar" "bar:baz"]
+              candidate {:foo "bar" :iss "foo:bar"}
+              signed    (make-jwt-fn candidate)]
+          (unsign-exp-succ signed candidate {:iss issuers})
+          (unsign-exp-fail signed :iss {:iss ["bar:foo" "baz:bar"]}))))
 
     (testing ":aud claim validation"
       (testing "single audience special case"


### PR DESCRIPTION
The tests are overly DRY for my liking and a bit obscure, but I think I got it. I had failing tests first, and made them pass.

Thanks for a great tool!