### PR TITLE
Update dependencies. Bump version 1.6.0

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,5 +1,14 @@
 = Changelog
 
+== Version 1.6.0
+
+Date: 2017-07-28
+
+- Update to use Clojure 1.9-alpha17
+- Update cheshire to 5.7.1
+- Update nippy to 2.13.0
+- Allows not just a single issuer, but also a collection of issuers, to be provided for validating the `iss` claim in a token
+
 == Version 1.5.0
 
 Date: 2017-03-30

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -1,6 +1,6 @@
 = buddy-sign - High level message signing.
 Andrey Antukh, <niwi@niwi.be>
-1.5.0
+1.6.0
 :toc: left
 :!numbered:
 :source-highlighter: pygments
@@ -45,7 +45,7 @@ dependency vector on your *_project.clj_* file:
 
 [source,clojure]
 ----
-[buddy/buddy-sign "1.5.0"]
+[buddy/buddy-sign "1.6.0"]
 ----
 
 And is tested under JDK7 and JDK8.

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,13 @@
-(defproject buddy/buddy-sign "1.5.0"
+(defproject buddy/buddy-sign "1.6.0"
   :description "High level message signing for Clojure"
   :url "https://github.com/funcool/buddy-sign"
   :license {:name "Apache 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha14" :scope "provided"]
-                 [com.taoensso/nippy "2.12.2" :scope "provided"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17" :scope "provided"]
+                 [com.taoensso/nippy "2.13.0" :scope "provided"]
                  [org.clojure/test.check "0.9.0" :scope "test"]
                  [buddy/buddy-core "1.2.0"]
-                 [cheshire "5.7.0"]]
+                 [cheshire "5.7.1"]]
   :source-paths ["src"]
   :javac-options ["-target" "1.7" "-source" "1.7" "-Xlint:-options"]
   :test-paths ["test"])


### PR DESCRIPTION
 - Clojure 1.9 alpha
 - Nippy
 - Cheshire

NB: The version should have also been bumped on the #48 PR merge.
NB: The changes documents should have also been updated in the #48 PR merge.