### PR TITLE
Allow for override expired claims check

### DIFF
--- a/src/buddy/sign/jwt.clj
+++ b/src/buddy/sign/jwt.clj
@@ -39,7 +39,8 @@
 
   `:now` is an integer POSIX time and defaults to the current time.
   `:leeway` is an integer number of seconds and defaults to zero."
-  [claims {:keys [max-age iss aud now leeway] :or {now (util/now) leeway 0}}]
+  [claims {:keys [max-age iss aud now leeway allow-expired]
+           :or {now (util/now) leeway 0 allow-expired false}}]
   (let [now (util/to-timestamp now)]
 
     ;; Check the `:iss` claim.
@@ -59,7 +60,8 @@
                       {:type :validation :cause :aud})))
 
     ;; Check the `:exp` claim.
-    (when (and (:exp claims) (<= (:exp claims) (- now leeway)))
+    (when (and (:exp claims) (<= (:exp claims) (- now leeway))
+            (not allow-expired))
       (throw (ex-info (format "Token is expired (%s)" (:exp claims))
                       {:type :validation :cause :exp})))
 

--- a/test/buddy/sign/jwt_tests.clj
+++ b/test/buddy/sign/jwt_tests.clj
@@ -109,7 +109,8 @@
         (unsign-exp-succ signed candidate {:now 10 :leeway 1})
         (unsign-exp-fail signed :exp {:now 10})
         (unsign-exp-fail signed :exp {:now 11})
-        (unsign-exp-fail signed :exp {:now 12 :leeway 1})))
+        (unsign-exp-fail signed :exp {:now 12 :leeway 1})
+        (unsign-exp-succ signed candidate {:now 11 :allow-expired true})))
 
     (testing ":nbf claim validation"
       (let [candidate {:foo "bar" :nbf 10}


### PR DESCRIPTION
I'd like to be able to inspect an expired token. This allows for a specific option `:allow-expired` in the options.