### PR TITLE
Use algorithm from header if present when unsigning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ script:
 jdk:
   - oraclejdk8
   - openjdk7
-  - oraclejdk7
+  - openjdk8
+  - openjdk9

--- a/src/buddy/sign/jws.clj
+++ b/src/buddy/sign/jws.clj
@@ -148,14 +148,14 @@
   "Given a signed message, verify it and return
   the decoded payload."
   ([input pkey] (unsign input pkey nil))
-  ([input pkey {:keys [alg] :or {alg :hs256}}]
+  ([input pkey {:keys [alg]}]
    (let [[header payload signature] (split-jws-message input)
          header-data (parse-header header)]
      (when-not
        (try
          (verify-signature {:key       (util/resolve-key pkey header-data)
                             :signature signature
-                            :alg       alg
+                            :alg       (or alg (:alg header-data) :hs256)
                             :header    header
                             :payload   payload})
          (catch java.security.SignatureException se

--- a/src/buddy/sign/jws.clj
+++ b/src/buddy/sign/jws.clj
@@ -77,13 +77,16 @@
 (defn- parse-header
   [^String data]
   (try
-    (let [header (-> (b64/decode data)
-                     (codecs/bytes->str)
-                     (json/parse-string true))]
+    (let [{:keys [alg] :as header} (-> (b64/decode data)
+                                       (codecs/bytes->str)
+                                       (json/parse-string true))]
       (when-not (map? header)
         (throw (ex-info "Message seems corrupt or manipulated."
                         {:type :validation :cause :header})))
-      (update header :alg #(keyword (str/lower-case %))))
+
+      (if alg
+        (assoc header :alg (keyword (str/lower-case alg)))
+        header))
     (catch com.fasterxml.jackson.core.JsonParseException e
       (throw (ex-info "Message seems corrupt or manipulated."
                       {:type :validation :cause :header})))))

--- a/test/buddy/sign/jws_tests.clj
+++ b/test/buddy/sign/jws_tests.clj
@@ -51,7 +51,7 @@
 (deftest jws-wrong-key
   (let [candidate "foo bar "
         result    (jws/sign candidate ec-privkey {:alg :es512})]
-    (unsign-exp-fail result :signature)))
+    (unsign-exp-fail result :signature {:alg :hs256})))
 
 (defspec jws-spec-alg-hs 500
   (props/for-all
@@ -69,6 +69,14 @@
    (let [res1 (jws/sign data rsa-privkey {:alg alg})
          res2 (jws/unsign res1 rsa-pubkey {:alg alg})]
      (is (bytes/equals? res2 (codecs/to-bytes data))))))
+
+(defspec jws-spec-alg-ps-and-rs-from-header 500
+   (props/for-all
+    [data (gen/one-of [gen/bytes gen/string])
+     alg (gen/elements [:ps512 :ps384 :ps256 :rs512 :rs384 :rs256])]
+     (let [res1 (jws/sign data rsa-privkey {:alg alg})
+           res2 (jws/unsign res1 rsa-pubkey)]
+       (is (bytes/equals? res2 (codecs/to-bytes data))))))
 
 (defspec jws-spec-custom-headers 500
   (props/for-all


### PR DESCRIPTION
Without this, it's necessary to parse the header before calling `unsign` which would then parses the headers and ignore the algorithm.

The algorithm can still be overridden via `opts` and defaults to `:hs256` as before if not supplied or present in the headers.

NOTE: second commit fixes some tests, third removes oraclejdk7 (which is no longer supported), and adds openjdk8/9 and oraclejdk9