### PR TITLE
Update test.check

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.10.1" :scope "provided"]
                  [com.taoensso/nippy "2.14.0" :scope "provided"]
-                 [org.clojure/test.check "0.9.0" :scope "test"]
+                 [org.clojure/test.check "0.10.0" :scope "test"]
                  [buddy/buddy-core "1.6.0"]]
   :source-paths ["src"]
   :javac-options ["-target" "1.7" "-source" "1.7" "-Xlint:-options"]

--- a/test/buddy/sign/compact_tests.clj
+++ b/test/buddy/sign/compact_tests.clj
@@ -40,7 +40,7 @@
                         gen/symbol
                         gen/keyword
                         (gen/such-that not-nan? gen/double)
-                        gen/int])))
+                        gen/small-integer])))
 
 
 (defspec compact-spec-alg-hs 50

--- a/test/buddy/sign/jwt_tests.clj
+++ b/test/buddy/sign/jwt_tests.clj
@@ -63,7 +63,7 @@
    [key (gen/one-of [gen/bytes gen/string])
     alg (gen/elements [:hs512 :hs256])
     data (gen/map (gen/resize 4 gen/keyword)
-                  (gen/one-of [gen/string-alphanumeric gen/int]))]
+                  (gen/one-of [gen/string-alphanumeric gen/small-integer]))]
    (let [res1 (jwt/sign data key {:alg alg})
          res2 (jwt/unsign res1 key {:alg alg})]
      (is (= res2 data)))))


### PR DESCRIPTION
`gen/int` was deprecated and `gen/small-integer` is its replacement.