### PR TITLE
Fix wrong version number in CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 3.4.351
+## Version 3.5.351
 
 Date: 2023-06-30
 


### PR DESCRIPTION
Was released as 3.5.351, not 3.4.351
ref https://clojars.org/buddy/buddy-sign/versions/3.5.351